### PR TITLE
Make 'insets' actually work

### DIFF
--- a/BubbleTagView.podspec
+++ b/BubbleTagView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "BubbleTagView"
-  s.version          = "0.1.5"
+  s.version          = "0.1.6"
   s.summary          = "Collection view subclass for displaying tags as bubbles"
 
 # This description is used to generate tags and improve search results.

--- a/Example/BubbleTagView/ViewController.swift
+++ b/Example/BubbleTagView/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController, BubbleTagViewDelegate {
         
         bubbleTagView.setTags(items)        
 
-        bubbleTagView.insets = UIEdgeInsetsMake(8,12, 8, 12)
+        bubbleTagView.insets = UIEdgeInsetsMake(0, 5, 0, 5)
         
     
     }

--- a/Pod/Classes/BubbleTagView.swift
+++ b/Pod/Classes/BubbleTagView.swift
@@ -47,10 +47,9 @@ public class BubbleTagView: UICollectionView, UICollectionViewDelegate, UICollec
     public var selectedCellColor: UIColor?
     public var selectedCellBorderColor : UIColor?
     public var insets : UIEdgeInsets? {
-        
-        willSet(newInsets) {
-            if let newInsets = newInsets {
-                self.sizingCell.insets = newInsets
+        didSet {
+            if let insets = insets {
+                self.sizingCell.insets = insets
                 self.reloadData()
             }
         }

--- a/Pod/Classes/BubbleTagViewCell.swift
+++ b/Pod/Classes/BubbleTagViewCell.swift
@@ -14,8 +14,8 @@ class BubbleTagViewCell: UICollectionViewCell {
     var customConstraints: [NSLayoutConstraint] = []
     
     var insets : UIEdgeInsets = BubbleTagViewConfiguration.inset {
-        didSet(newInsets) {
-            
+        didSet {
+            self.contentView.layoutMargins = insets
         }
         
     }
@@ -115,11 +115,12 @@ class BubbleTagViewCell: UICollectionViewCell {
         
         let views = ["label": self.tagLabel]
         
-        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-5-[label]-5-|", options: NSLayoutFormatOptions(), metrics: nil, views: views)
-        let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|-0-[label(22)]-0-|", options: NSLayoutFormatOptions(), metrics: nil, views: views)
+        let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-[label]-|", options: NSLayoutFormatOptions(), metrics: nil, views: views)
+        let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|-[label(22)]-|", options: NSLayoutFormatOptions(), metrics: nil, views: views)
         
         self.contentView.addConstraints(horizontalConstraints)
         self.contentView.addConstraints(verticalConstraints)
+        self.contentView.layoutMargins = insets
     }
     
     

--- a/Pod/Classes/BubbleTagViewConfiguration.swift
+++ b/Pod/Classes/BubbleTagViewConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class BubbleTagViewConfiguration {
     /// View insets
-    public static var inset: UIEdgeInsets = UIEdgeInsetsMake(5, 5, 5, 5)
+    public static var inset: UIEdgeInsets = UIEdgeInsetsMake(0, 5, 0, 5)
     
     /// Height for item
     public static var cellHeight: CGFloat = 22.0


### PR DESCRIPTION
Both `BubbleTagView` and `BubbleTagViewCell` have `var insets: UIEdgeInsets` properties but setting it didn't work. Until now.

How it works: It uses autolayout's margins to set the padding on the cell's `contentView`.
